### PR TITLE
Add migration_id to DELETE unmatched_rows query

### DIFF
--- a/src/sbosc/controller/initializer.py
+++ b/src/sbosc/controller/initializer.py
@@ -134,7 +134,7 @@ class Initializer:
                     source_pk bigint,
                     migration_id int,
                     unmatch_type varchar(128),
-                    KEY `idx_unmatched_rows_migration_id` (`migration_id`)
+                    KEY `idx_unmatched_rows_migration_id_source_pk` (`migration_id`, `source_pk`)
                 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
             ''')
             self.logger.info("Unmatched rows table created")

--- a/src/sbosc/controller/validator.py
+++ b/src/sbosc/controller/validator.py
@@ -241,7 +241,7 @@ class DataValidator:
                         matched_pks_str = ','.join([str(pk) for pk in matched_pks])
                         cursor.execute(f'''
                             DELETE FROM {config.SBOSC_DB}.unmatched_rows WHERE source_pk IN ({matched_pks_str})
-                            AND unmatch_type = '{UnmatchType.NOT_UPDATED}'
+                            AND unmatch_type = '{UnmatchType.NOT_UPDATED}' AND migration_id = {self.migration_id}
                         ''')
                 if len(not_removed_pks) > 0:
                     matched_pks = self.migration_operation.get_rematched_removed_pks(self.db, not_removed_pks)
@@ -250,7 +250,7 @@ class DataValidator:
                         matched_pks_str = ','.join([str(pk) for pk in matched_pks])
                         cursor.execute(f'''
                             DELETE FROM {config.SBOSC_DB}.unmatched_rows WHERE source_pk IN ({matched_pks_str})
-                            AND unmatch_type = '{UnmatchType.NOT_REMOVED}'
+                            AND unmatch_type = '{UnmatchType.NOT_REMOVED}' AND migration_id = {self.migration_id}
                         ''')
                 self.redis_data.updated_pk_set.add(not_updated_pks - not_removed_pks)
                 self.redis_data.updated_pk_set.remove(not_removed_pks)

--- a/src/sbosc/operations/base.py
+++ b/src/sbosc/operations/base.py
@@ -117,7 +117,7 @@ class BaseOperation(MigrationOperation):
                 SELECT source_pk FROM {config.SBOSC_DB}.unmatched_rows WHERE source_pk NOT IN (
                     SELECT id FROM {self.destination_db}.{self.destination_table}
                     WHERE id IN ({not_removed_pks_str})
-                ) AND source_pk IN ({not_removed_pks_str})
+                ) AND source_pk IN ({not_removed_pks_str}) AND migration_id = {self.migration_id}
             ''')
             rematched_pks = set([row[0] for row in cursor.fetchall()])
             # add reinserted pks
@@ -268,7 +268,7 @@ class CrossClusterBaseOperation(MigrationOperation):
             cursor: Cursor
             query = f'''
                 SELECT source_pk FROM {config.SBOSC_DB}.unmatched_rows
-                WHERE source_pk IN ({not_removed_pks_str})
+                WHERE source_pk IN ({not_removed_pks_str}) AND migration_id = {self.migration_id}
             '''
             if still_not_removed_pks_str:
                 query += f" AND source_pk NOT IN ({still_not_removed_pks_str})"


### PR DESCRIPTION
- Add the `source_pk` column to the `unmatched_rows` table index. This improves the performance of `DELETE` queries executed during `validate_unmatched_pks`.
- Add `migration_id` to the WHERE clause of queries made on the `unmatched_rows` table. This fixes a possible data inconsistency risk that may occur under the following conditions:
  - Two or more migrations are executed concurrently in the same cluster.
  - Both migrations initially fail to apply a DML event on the same PK.
  - Only one of the tables is recovered, but both `unmatched_rows` records are removed due to the missing WHERE clause.
  - The same problem occurs even after the `full_dml_validation` step.