### PR TITLE
Run full dml event validation when auto_swap is false

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -280,6 +280,8 @@ def test_apply_dml_events_validation(controller: Controller, setup_table, redis_
 
     # Test full validation
     assert controller.validator.full_dml_event_validation()
+    cursor.execute(f"SELECT is_valid FROM {config.SBOSC_DB}.full_dml_event_validation_status")
+    assert cursor.fetchone()[0] == 1
 
     cursor.execute(f"USE {config.SBOSC_DB}")
     cursor.execute("TRUNCATE TABLE event_handler_status")


### PR DESCRIPTION
`full_dml_event_validation` did not run when `auto_swap` is false.
It was intended to run in such cases, especially when using `CrossClusterBaseMigration` (which sets `auto_swap` to false by default)
Corrected it to run properly when `auto_swap` is false