### PR TITLE
DDL session variables (MySQL 8.0.27 and above)

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -68,6 +68,9 @@ class Config:
     OPERATION_CLASS = 'BaseOperation'
     INDEXES = []
     INDEX_CREATED_PER_QUERY = 4
+    INNODB_DDL_BUFFER_SIZE = None  # optional
+    INNODB_DDL_THREADS = None  # optional
+    INNODB_PARALLEL_READ_THREADS = None  # optional
 
     # Worker config
     MIN_BATCH_SIZE = 100

--- a/src/sbosc/controller/controller.py
+++ b/src/sbosc/controller/controller.py
@@ -270,6 +270,19 @@ class Controller(SBOSCComponent):
                 # add index
                 with self.db.cursor(host='dest') as cursor:
                     cursor: Cursor
+
+                    # set session variables
+                    if config.INNODB_DDL_BUFFER_SIZE is not None:
+                        cursor.execute(f"SET SESSION innodb_ddl_buffer_size = {config.INNODB_DDL_BUFFER_SIZE}")
+                        self.logger.info(f"Set innodb_ddl_buffer_size to {config.INNODB_DDL_BUFFER_SIZE}")
+                    if config.INNODB_DDL_THREADS is not None:
+                        cursor.execute(f"SET SESSION innodb_ddl_threads = {config.INNODB_DDL_THREADS}")
+                        self.logger.info(f"Set innodb_ddl_threads to {config.INNODB_DDL_THREADS}")
+                    if config.INNODB_PARALLEL_READ_THREADS is not None:
+                        cursor.execute(
+                            f"SET SESSION innodb_parallel_read_threads = {config.INNODB_PARALLEL_READ_THREADS}")
+                        self.logger.info(f"Set innodb_parallel_read_threads to {config.INNODB_PARALLEL_READ_THREADS}")
+
                     cursor.execute(f'''
                         ALTER TABLE {metadata.destination_db}.{metadata.destination_table}
                         {', '.join([

--- a/tests/configs/config.yaml
+++ b/tests/configs/config.yaml
@@ -15,6 +15,9 @@ skip_bulk_import: False
 operation_class: BaseOperation
 indexes: []
 index_created_per_query: 4
+innodb_ddl_buffer_size: 1048576
+innodb_ddl_threads: 4
+innodb_parallel_read_threads: 4
 
 # Worker config
 min_batch_size: 100


### PR DESCRIPTION
New innodb parameters were realeased in MySQL 8.0.27
which can substantially reduce creation time of secondary indexes on large tables
- `innodb_buffer_size`
- `innodb_ddl_threads`
- `innodb_parallel_read_threads`

Add support for these parameters when creating index after bulk import