### PR TITLE
Fix bug on duplicate key

### DIFF
--- a/src/sbosc/worker/worker.py
+++ b/src/sbosc/worker/worker.py
@@ -116,6 +116,10 @@ class Worker:
             start_pk = self.get_start_pk(chunk_info)
             if start_pk is None:
                 return
+            # If the start_pk is greater than the end_pk, set the last_pk_inserted to end_pk
+            # This can happen when chunk ended with a duplicate key error
+            elif start_pk > chunk_info.end_pk:
+                chunk_info.last_pk_inserted = chunk_info.end_pk
 
             end_pk = chunk_info.end_pk
             chunk_info.status = ChunkStatus.IN_PROGRESS


### PR DESCRIPTION
When chunk is at `DUPLICATE_KEY` state and calculated `start_pk` is bigger than `end_pk`,
It can be considered as `DONE` state.
Currently, it doesn't update `last_inserted_pk` of chunk's status which caused chunk to retry indefinitely.
Fixed to update `last_inserted_pk` to `end_pk` when received `start_pk` is bigger than `end_pk`