### PR TITLE
Auto detect PK column

### DIFF
--- a/doc/operation-class.md
+++ b/doc/operation-class.md
@@ -27,7 +27,7 @@ class MessageRetentionOperation(BaseOperation):
             INSERT INTO {self.source_db}.{self.destination_table}({self.source_columns})
             SELECT {self.source_columns}
             FROM {self.source_db}.{self.source_table} AS source
-            WHERE source. BETWEEN {start_pk} AND {end_pk}
+            WHERE source.{self.pk_column} BETWEEN {start_pk} AND {end_pk}
             AND source.ts > DATE_SUB(NOW(), INTERVAL 30 DAY)
         """
     def _get_not_imported_pks_query(self, start_pk, end_pk):

--- a/src/modules/redis/schema.py
+++ b/src/modules/redis/schema.py
@@ -28,7 +28,8 @@ class Metadata(Hash):
     destination_db: str
     destination_table: str
     source_columns: str
-    max_id: int
+    pk_column: str
+    max_pk: int
     start_datetime: datetime
 
 

--- a/src/sbosc/controller/initializer.py
+++ b/src/sbosc/controller/initializer.py
@@ -186,7 +186,9 @@ class Initializer:
             self.logger.info("Saved primary key column to Redis")
 
             # Get max id
-            cursor.execute("SELECT MAX(%s) FROM %s.%s" % (metadata.pk_column, metadata.source_db, metadata.source_table))
+            cursor.execute('''
+                SELECT MAX(%s) FROM %s.%s
+            ''' % (metadata.pk_column, metadata.source_db, metadata.source_table))
             max_pk = cursor.fetchone()[0]
             if max_pk is None:
                 raise Exception("No data in source table")

--- a/src/sbosc/controller/validator.py
+++ b/src/sbosc/controller/validator.py
@@ -153,13 +153,15 @@ class DataValidator:
             if event_pks:
                 event_pks_str = ','.join([str(pk) for pk in event_pks])
                 dest_cursor.execute(f'''
-                    SELECT {metadata.pk_column} FROM {metadata.destination_db}.{metadata.destination_table} WHERE {metadata.pk_column} IN ({event_pks_str})
+                    SELECT {metadata.pk_column} FROM {metadata.destination_db}.{metadata.destination_table}
+                    WHERE {metadata.pk_column} IN ({event_pks_str})
                 ''')
                 not_deleted_pks = set([row[0] for row in dest_cursor.fetchall()])
                 if dest_cursor.rowcount > 0:
                     # Check if deleted pks are reinserted
                     source_cursor.execute(f'''
-                        SELECT {metadata.pk_column} FROM {metadata.source_db}.{metadata.source_table} WHERE {metadata.pk_column} IN ({event_pks_str})
+                        SELECT {metadata.pk_column} FROM {metadata.source_db}.{metadata.source_table}
+                        WHERE {metadata.pk_column} IN ({event_pks_str})
                     ''')
                     reinserted_pks = set([row[0] for row in source_cursor.fetchall()])
                     if reinserted_pks:

--- a/src/sbosc/controller/validator.py
+++ b/src/sbosc/controller/validator.py
@@ -83,8 +83,8 @@ class DataValidator:
         metadata = self.redis_data.metadata
         range_queue = Queue()
         start_pk = 0
-        while start_pk <= metadata.max_id:
-            range_queue.put((start_pk, min(start_pk + self.bulk_import_batch_size, metadata.max_id)))
+        while start_pk <= metadata.max_pk:
+            range_queue.put((start_pk, min(start_pk + self.bulk_import_batch_size, metadata.max_pk)))
             start_pk += self.bulk_import_batch_size + 1
         failed_pks = []
 
@@ -153,13 +153,13 @@ class DataValidator:
             if event_pks:
                 event_pks_str = ','.join([str(pk) for pk in event_pks])
                 dest_cursor.execute(f'''
-                    SELECT id FROM {metadata.destination_db}.{metadata.destination_table} WHERE id IN ({event_pks_str})
+                    SELECT {metadata.pk_column} FROM {metadata.destination_db}.{metadata.destination_table} WHERE {metadata.pk_column} IN ({event_pks_str})
                 ''')
                 not_deleted_pks = set([row[0] for row in dest_cursor.fetchall()])
                 if dest_cursor.rowcount > 0:
                     # Check if deleted pks are reinserted
                     source_cursor.execute(f'''
-                        SELECT id FROM {metadata.source_db}.{metadata.source_table} WHERE id IN ({event_pks_str})
+                        SELECT {metadata.pk_column} FROM {metadata.source_db}.{metadata.source_table} WHERE {metadata.pk_column} IN ({event_pks_str})
                     ''')
                     reinserted_pks = set([row[0] for row in source_cursor.fetchall()])
                     if reinserted_pks:

--- a/src/sbosc/monitor/monitor.py
+++ b/src/sbosc/monitor/monitor.py
@@ -306,8 +306,8 @@ class MetricMonitor(SBOSCComponent):
             if last_pk_inserted and last_pk_inserted >= chunk_info.start_pk:
                 inserted_rows += last_pk_inserted - chunk_info.start_pk
 
-        if self.redis_data.metadata.max_id:
-            bulk_import_progress = inserted_rows / self.redis_data.metadata.max_id * 100
+        if self.redis_data.metadata.max_pk:
+            bulk_import_progress = inserted_rows / self.redis_data.metadata.max_pk * 100
             self.metric_sender.submit('sb_osc_bulk_import_progress', bulk_import_progress)
 
         self.submit_event_handler_timestamps()

--- a/src/sbosc/operations/base.py
+++ b/src/sbosc/operations/base.py
@@ -41,7 +41,8 @@ class BaseOperation(MigrationOperation):
     def _get_not_imported_pks_query(self, start_pk, end_pk):
         return f'''
             SELECT source.{self.pk_column} FROM {self.source_db}.{self.source_table} AS source
-            LEFT JOIN {self.destination_db}.{self.destination_table} AS dest ON source.{self.pk_column} = dest.{self.pk_column}
+            LEFT JOIN {self.destination_db}.{self.destination_table} AS dest
+            ON source.{self.pk_column} = dest.{self.pk_column}
             WHERE source.{self.pk_column} BETWEEN {start_pk} AND {end_pk}
             AND dest.{self.pk_column} IS NULL
         '''

--- a/src/sbosc/operations/operation.py
+++ b/src/sbosc/operations/operation.py
@@ -30,6 +30,7 @@ class MigrationOperation:
         self.destination_table = metadata.destination_table
         self.source_columns: str = metadata.source_columns
         self.source_column_list: list = metadata.source_columns.split(',')
+        self.pk_column = metadata.pk_column
         self.start_datetime = metadata.start_datetime
 
         self.operation_config = self.operation_config_class(**config.OPERATION_CLASS_CONFIG)

--- a/src/sbosc/operations/utils.py
+++ b/src/sbosc/operations/utils.py
@@ -6,5 +6,5 @@ def insert_to_upsert(query: str, source_columns: list) -> str:
     return query
 
 
-def apply_limit(query: str, limit: int) -> str:
-    return query + f" ORDER BY id LIMIT {limit}"
+def apply_limit(query: str, pk_column: str, limit: int) -> str:
+    return query + f" ORDER BY {pk_column} LIMIT {limit}"

--- a/src/sbosc/worker/worker.py
+++ b/src/sbosc/worker/worker.py
@@ -207,8 +207,8 @@ class Worker:
         with self.db.cursor(host='dest') as cursor:
             cursor: Cursor
             cursor.execute(f'''
-                SELECT MAX(id) FROM {metadata.destination_db}.{metadata.destination_table}
-                WHERE id BETWEEN {start_pk} AND {end_pk}
+                SELECT MAX({metadata.pk_column}) FROM {metadata.destination_db}.{metadata.destination_table}
+                WHERE {metadata.pk_column} BETWEEN {start_pk} AND {end_pk}
             ''')
             return cursor.fetchone()[0]
 
@@ -243,7 +243,7 @@ class Worker:
             removed_pks_str = ",".join([str(pk) for pk in removed_pks])
             query = f"""
                 DELETE FROM {metadata.destination_db}.{metadata.destination_table}
-                WHERE id IN ({removed_pks_str})
+                WHERE {metadata.pk_column} IN ({removed_pks_str})
             """
             cursor.execute(query)
         return cursor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,8 +89,9 @@ def init_migration(config, cursor, redis_data, migration_id):
         cursor.execute(f'DROP DATABASE IF EXISTS {db}')
         cursor.execute(f'CREATE DATABASE {db}')
 
-    cursor.execute(f'CREATE TABLE {config.SOURCE_DB}.{config.SOURCE_TABLE} (id int)')
-    cursor.execute(f'CREATE TABLE {config.DESTINATION_DB}.{config.DESTINATION_TABLE} (id int)')
+    cursor.execute(f'CREATE TABLE {config.SOURCE_DB}.{config.SOURCE_TABLE} (id int AUTO_INCREMENT PRIMARY KEY)')
+    cursor.execute(f'INSERT INTO {config.SOURCE_DB}.{config.SOURCE_TABLE} VALUES (1)')
+    cursor.execute(f'CREATE TABLE {config.DESTINATION_DB}.{config.DESTINATION_TABLE} (id int AUTO_INCREMENT PRIMARY KEY)')
 
     retrieved_migration_id = Initializer().init_migration()
 

--- a/tests/test_eventhandler.py
+++ b/tests/test_eventhandler.py
@@ -97,7 +97,7 @@ def test_event_handler_save_to_database(event_handler, cursor, redis_data):
     time.sleep(100)
 
     total_events = 1000
-    redis_data.metadata.max_id = total_events
+    redis_data.metadata.max_pk = total_events
     insert_events = total_events // 2
     update_events = (total_events - insert_events) // 2
     delete_events = total_events - insert_events - update_events

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -113,7 +113,7 @@ def test_update_worker_config(monitor, redis_data):
 def test_check_migration_status(monitor, cursor, redis_data):
     cursor.execute(f"TRUNCATE TABLE {config.SBOSC_DB}.event_handler_status")
     cursor.execute(f"TRUNCATE TABLE {config.SBOSC_DB}.apply_dml_events_status")
-    monitor.redis_data.metadata.max_id = 0
+    monitor.redis_data.metadata.max_pk = 0
     monitor.check_migration_status()
     metric_set = get_metric_names(monitor)
     expected_metrics = {
@@ -124,7 +124,7 @@ def test_check_migration_status(monitor, cursor, redis_data):
     }
     assert metric_set == expected_metrics
 
-    monitor.redis_data.metadata.max_id = 100
+    monitor.redis_data.metadata.max_pk = 100
     monitor.check_migration_status()
     metric_set = get_metric_names(monitor)
     expected_metrics.add('sb_osc_bulk_import_progress')


### PR DESCRIPTION
Originally SB-OSC only supported primary key columns named "id".
This patch makes SB-OSC automatically detect primary key column and use it inside its queries.