### PR TITLE
Support PK without AUTO_INCREMENT

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -34,3 +34,6 @@ These parameters control insert throughput of SB-OSC. `batch_size` and `thread_c
 
 `LIMIT batch_size` is applied to the next query to prevent from inserting too many rows at once.
 
+**Note:** This option utilizes cursor.lastrowid to the `last_inserted_pk` which only returns non-zero value when table has **AUTO_INCREMENT** column.
+([MySQL Document](https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlcursor-lastrowid.html))
+

--- a/src/sbosc/controller/controller.py
+++ b/src/sbosc/controller/controller.py
@@ -52,7 +52,6 @@ class Controller(SBOSCComponent):
             if action:
                 action()
 
-            # TODO: Add Redis data validation if needed
             time.sleep(self.interval)
 
         # Close db connection

--- a/src/sbosc/controller/initializer.py
+++ b/src/sbosc/controller/initializer.py
@@ -178,7 +178,7 @@ class Initializer:
             cursor.execute(f'''
                 SELECT COLUMN_NAME FROM information_schema.COLUMNS
                 WHERE TABLE_SCHEMA = '{metadata.source_db}' AND TABLE_NAME = '{metadata.source_table}'
-                AND COLUMN_KEY = 'PRI' AND EXTRA LIKE '%auto_increment%'
+                AND COLUMN_KEY = 'PRI' AND DATA_TYPE IN ('int', 'bigint')
             ''')
             if cursor.rowcount == 0:
                 raise Exception("Auto increment primary key column not found")

--- a/src/sbosc/controller/initializer.py
+++ b/src/sbosc/controller/initializer.py
@@ -181,7 +181,7 @@ class Initializer:
                 AND COLUMN_KEY = 'PRI' AND DATA_TYPE IN ('int', 'bigint')
             ''')
             if cursor.rowcount == 0:
-                raise Exception("Auto increment primary key column not found")
+                raise Exception("Integer primary key column not found")
             metadata.pk_column = f"`{cursor.fetchone()[0]}`"
             self.logger.info("Saved primary key column to Redis")
 

--- a/src/sbosc/controller/initializer.py
+++ b/src/sbosc/controller/initializer.py
@@ -185,7 +185,7 @@ class Initializer:
             metadata.pk_column = f"`{cursor.fetchone()[0]}`"
             self.logger.info("Saved primary key column to Redis")
 
-            # Get max id
+            # Get max PK
             cursor.execute('''
                 SELECT MAX(%s) FROM %s.%s
             ''' % (metadata.pk_column, metadata.source_db, metadata.source_table))

--- a/src/sbosc/worker/worker.py
+++ b/src/sbosc/worker/worker.py
@@ -144,7 +144,11 @@ class Worker:
                     self.worker_config.update_batch_size_multiplier(cursor.rowcount)
 
                 # update last pk inserted
-                if cursor.rowcount == self.worker_config.raw_batch_size:
+                # If batch size multiplier is used,
+                # there can be remaining rows between cursor.lastrowid and batch_end_pk
+                # because of the limit clause in the query.
+                # Note that cursor.lastrowid is a non-zero value only if pk is auto-incremented.
+                if self.use_batch_size_multiplier and cursor.rowcount == self.worker_config.raw_batch_size:
                     last_pk_inserted = cursor.lastrowid
                 else:
                     last_pk_inserted = batch_end_pk


### PR DESCRIPTION
This change allows SB-OSC to operate on tables without AUTO_INCREMENT option on PK
- Change query filter when detecting PK column for fetch_metadata
- lastrowid of cursor, which returns non-zero value only when AUTO_INCREMENT PK exists, is used for `use_batch_size_multiplier` option. Fixed it to only use lastrowid when `use_batch_size_multiplier` is enabled