### PR TITLE
except TypeError in get_rematched_updated_pks

### DIFF
--- a/src/sbosc/operations/base.py
+++ b/src/sbosc/operations/base.py
@@ -280,7 +280,7 @@ class CrossClusterBaseOperation(MigrationOperation):
             dest_df = dest_df.astype(source_df.dtypes.to_dict())
             merged_df = source_df.merge(dest_df, how='inner', on=source_df.columns.tolist(), indicator=True)
             rematched_pks = set(merged_df[merged_df['_merge'] == 'both'][self.pk_column.strip('`')].tolist())
-        except pd.errors.IntCastingNaNError:
+        except (pd.errors.IntCastingNaNError, TypeError):
             rematched_pks = set()
         # add deleted pks
         with db.cursor(host='source', role='reader') as cursor:


### PR DESCRIPTION
TypeError occurred when integer column has NULL in destination and int value in source.
Return empty set for rematched pks in case of above exception.